### PR TITLE
fix: forward-androidHardwareAccelerationDisabled to WebView

### DIFF
--- a/src/LeafletView/index.tsx
+++ b/src/LeafletView/index.tsx
@@ -48,6 +48,7 @@ export type LeafletViewProps = {
   ownPositionMarker?: OwnPositionMarker;
   zoom?: number;
   doDebug?: boolean;
+  androidHardwareAccelerationDisabled?: boolean;
 };
 
 const LeafletView: React.FC<LeafletViewProps> = ({
@@ -63,6 +64,7 @@ const LeafletView: React.FC<LeafletViewProps> = ({
   ownPositionMarker,
   zoom,
   doDebug,
+  androidHardwareAccelerationDisabled,
 }) => {
   const webViewRef = useRef<WebView>(null);
   const [initialized, setInitialized] = useState(false);
@@ -213,6 +215,7 @@ const LeafletView: React.FC<LeafletViewProps> = ({
       allowFileAccess={true}
       allowUniversalAccessFromFileURLs={true}
       allowFileAccessFromFileURLs={true}
+      androidHardwareAccelerationDisabled={androidHardwareAccelerationDisabled}
     />
   );
 };


### PR DESCRIPTION
This enables a workaround for a crash in combination with
react-navigation. See
https://github.com/react-navigation/react-navigation/issues/9067#issuecomment-728074223