### PR TITLE
fix: default map layer attribution http url and copyright symbol

### DIFF
--- a/src/LeafletView/index.tsx
+++ b/src/LeafletView/index.tsx
@@ -26,7 +26,7 @@ const LEAFLET_HTML_SOURCE = Platform.select({
 const DEFAULT_MAP_LAYERS = [
   {
     attribution:
-      '&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
+      '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
     baseLayerIsChecked: true,
     baseLayerName: 'OpenStreetMap.Mapnik',
     url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',


### PR DESCRIPTION
Fixed the OSM copyright link which was still using HTTP instead of HTTPS (in non-react leaflet this had been fixed years ago). 
The attribution link has also been changed identically as it had ben done in [Leaflet](https://github.com/Leaflet/Leaflet) (see 
https://github.com/Leaflet/Leaflet/blob/9f9c5497560374f6d0659c08add5f37b8453621f/docs/_layouts/v2.html#L56).

I also noticed that the copyright symbol was defect (instead of &copy; it showed `&copy`, see your [project screen shots](https://github.com/pavel-corsaghin/react-native-leaflet/blob/main/images/ios.png?raw=true)), this is now fixed.