### PR TITLE
fix: own position marker should always have the same id

### DIFF
--- a/src/LeafletView/index.tsx
+++ b/src/LeafletView/index.tsx
@@ -179,7 +179,10 @@ const LeafletView: React.FC<LeafletViewProps> = ({
     if (!initialized || !ownPositionMarker) {
       return;
     }
-    sendMessage({ ownPositionMarker });
+    sendMessage({
+	  ...ownPositionMarker,
+	  id: OWN_POSTION_MARKER_ID
+	});
   }, [initialized, ownPositionMarker, sendMessage]);
 
   //Handle mapCenterPosition update


### PR DESCRIPTION
The ownPositionMarker is a simple marker with a special id. When not provided explicitly, this id seems to be generated randomly, which results in ownPositionMarker being duplicated every time we update it.
Please, also see old [issue ](https://github.com/reggie3/react-native-webview-leaflet/issues/105) in the parent [repository](https://github.com/reggie3/react-native-webview-leaflet) that had remained unaddressed until recently.