### PR TITLE
Module Leaflet requires main queue setup

### DIFF
--- a/ios/Leaflet.m
+++ b/ios/Leaflet.m
@@ -2,6 +2,11 @@
 
 @interface RCT_EXTERN_MODULE(Leaflet, NSObject)
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 RCT_EXTERN_METHOD(multiply:(float)a withB:(float)b
                  withResolver:(RCTPromiseResolveBlock)resolve
                  withRejecter:(RCTPromiseRejectBlock)reject)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-native-leaflet-view",
-  "version": "0.1.2",
+  "name": "react-native-leaflet-custom-view",
+  "version": "1.0.0",
   "description": "A LeafletView component using WebView and Leaflet map for React Native applications",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
Module Leaflet requires main queue setup since it overrides `init` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.