### PR TITLE
Revert name package to original name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-leaflet-custom-view",
+  "name": "react-native-leaflet-view",
   "version": "1.0.0",
   "description": "A LeafletView component using WebView and Leaflet map for React Native applications",
   "main": "lib/commonjs/index",


### PR DESCRIPTION
Commit https://github.com/pavel-corsaghin/react-native-leaflet/pull/51 accidentally changed the name of the package. This commit reverts the package name back to the original.